### PR TITLE
remove delays for sqs queue (only)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,10 +16,8 @@ resource "random_string" "random" {
 
 resource "aws_sqs_queue" "queued_builds" {
   name                        = "${var.environment}-queued-builds.fifo"
-  delay_seconds               = 30
   visibility_timeout_seconds  = var.runners_scale_up_lambda_timeout
   fifo_queue                  = true
-  receive_wait_time_seconds   = 10
   content_based_deduplication = true
 
   tags = var.tags


### PR DESCRIPTION
We had noticed scaling issues and long queue times for messages within
sqs, this is probably the first step to actually just removing the
separate webhook and serving requests directly to the scale up lambda

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>