### PR TITLE
Simplify scale-down, attempt to de-register before terminating

### DIFF
--- a/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -1,4 +1,5 @@
 import { Octokit } from '@octokit/rest';
+import { bool } from 'aws-sdk/clients/signer';
 import moment from 'moment';
 import {
   listRunners,
@@ -19,30 +20,6 @@ function runnerMinimumTimeExceeded(runner: RunnerInfo, minimumRunningTimeInMinut
   const launchTimePlusMinimum = moment(runner.launchTime).utc().add(minimumRunningTimeInMinutes, 'minutes');
   const now = moment(new Date()).utc();
   return launchTimePlusMinimum < now;
-}
-
-async function removeRunner(
-  ec2runner: RunnerInfo,
-  ghRunnerId: number,
-  repo: Repo,
-  githubAppClient: Octokit,
-): Promise<void> {
-  try {
-    const result = await githubAppClient.actions.deleteSelfHostedRunnerFromRepo({
-      runner_id: ghRunnerId,
-      owner: repo.repoOwner,
-      repo: repo.repoName,
-    });
-
-    if (result.status == 204) {
-      await terminateRunner(ec2runner);
-      console.info(
-        `AWS runner instance '${ec2runner.instanceId}' [${ec2runner.runnerType}] is terminated and GitHub runner is de-registered.`,
-      );
-    }
-  } catch (e) {
-    console.warn(`Error scaling down '${ec2runner.instanceId}' [${ec2runner.runnerType}]: ${e}`);
-  }
 }
 
 export async function scaleDown(): Promise<void> {
@@ -84,32 +61,33 @@ export async function scaleDown(): Promise<void> {
     const repo = getRepo(ec2runner.org, ec2runner.repo, enableOrgLevel);
     const ghRunners = await listGithubRunners(githubAppClient, ec2runner.org, ec2runner.repo, enableOrgLevel);
     let ghRunner: GhRunner | undefined = ghRunners.find((runner) => runner.name === ec2runner.instanceId);
-    // Github's / Octokit's list for self hosted runners is inconsistent when listing out pages > 1
-    // so we attempt to do a sanity check here to make sure that the instance itself is actually
-    // orphaned and not busy, the ghRunnerId will only be populated if the runner was actually
-    // registered to Github so this should be a fairly safe call to make
-    if (ghRunner === undefined && ec2runner.ghRunnerId !== undefined) {
-      console.warn(
-        `Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] not found in listGithubRunners call, attempting to grab directly`,
-      );
-      ghRunner = await getRunner(githubAppClient, repo.repoOwner, repo.repoName, ec2runner.ghRunnerId);
+    // ec2Runner matches a runner that's registered to github and that runner is marked as busy
+    if (ghRunner && ghRunner.busy) {
+      console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] is busy, skipping`);
+      continue;
     }
-    // ec2Runner matches a runner that's registered to github
-    if (ghRunner) {
-      if (ghRunner.busy) {
-        console.debug(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] is busy, skipping`);
-        continue;
-      } else {
-        await removeRunner(ec2runner, ghRunner.id, repo, githubAppClient);
-      }
-    } else {
-      // Remove orphan AWS runners.
-      console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] is orphaned, and will be removed.`);
-      try {
-        await terminateRunner(ec2runner);
-      } catch (e) {
-        console.error(`Orphan runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] cannot be removed: ${e}`);
-      }
+    // First attempt to de-register runner from Github, catch scenario should only happen
+    // when attempting to de-register a runner that is currently running a job
+    // Attempting to de-register a non-existent runner will result in a continuation to terminate
+    // the instance on AWS
+    try {
+      console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] will be de-registered from Github`);
+      await githubAppClient.actions.deleteSelfHostedRunnerFromRepo({
+        runner_id: Number(ec2runner.ghRunnerId),
+        owner: repo.repoOwner,
+        repo: repo.repoName,
+      });
+    } catch (e) {
+      // Shoud catch scenarios when attempting to de-register a runner that is currently running a job
+      console.warn(`Error de-registering '${ec2runner.instanceId}' [${ec2runner.runnerType}]: ${e}`);
+      return;
+    }
+    // Remove orphan AWS runners.
+    console.info(`Runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] will be terminated on AWS`);
+    try {
+      await terminateRunner(ec2runner);
+    } catch (e) {
+      console.error(`Orphan runner '${ec2runner.instanceId}' [${ec2runner.runnerType}] cannot be removed: ${e}`);
     }
   }
 }


### PR DESCRIPTION
This attempts to de-register the runner from Github before actually
attempting to terminate it on AWS in the hope that the de-registering
will catch runners that are still running jobs.

This may result in an uptick for our API calls but this is mostly to
mitigate issues we're seeing with both the list runners call as well as
the get individual runners call

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>